### PR TITLE
Poprawienie linków zawierających  `|` w #45

### DIFF
--- a/_posts/2022-10-07-45.md
+++ b/_posts/2022-10-07-45.md
@@ -14,12 +14,12 @@ Ciekawe linki i inne znaleziska z tego odcinka:
 * [Why We Are Changing the License for Akka](https://www.lightbend.com/blog/why-we-are-changing-the-license-for-akka)
 * [LinkedIn](https://www.linkedin.com/posts/jdegoes_functional-scala-2022-activity-6973304868094550016-qtvQ)
 * [Mongo Atlas](https://www.mongodb.com/atlas/database?utm_source=substack&utm_medium=email)
-* [Akka - Build Reactive Microservices | Lightbend](https://www.linkedin.com/posts/jdegoes_functional-scala-2022-activity-6973304868094550016-qtvQ)
+* [Akka - Build Reactive Microservices \| Lightbend](https://www.linkedin.com/posts/jdegoes_functional-scala-2022-activity-6973304868094550016-qtvQ)
 * [Elastic Cloud](https://www.elastic.co/cloud/?utm_source=substack&utm_medium=email)
 * [Event Store Cloud](https://www.eventstore.com/event-store-cloud?utm_source=substack&utm_medium=email)
-* [Fair Trade Software License | Duende Software Blog](https://blog.duendesoftware.com/posts/20220111_fair_trade/?utm_source=substack&utm_medium=email)
+* [Fair Trade Software License \| Duende Software Blog](https://blog.duendesoftware.com/posts/20220111_fair_trade/?utm_source=substack&utm_medium=email)
 * [Open source biz shifts Akka to Business Source License • The Register](https://www.theregister.com/2022/09/08/open_source_biz_sick_of/?utm_source=substack&utm_medium=email)
-* [Twitter](https://t.co/duwrvCOEKM I thought that .NET community deserves to know how that looks internally)
+* [Twitter](https://t.co/duwrvCOEKM) I thought that .NET community deserves to know how that looks internally
 * [Azure Managed Grafana](https://azure.microsoft.com/en-us/services/managed-grafana/#features)
 * [Open Cybersecurity Schema Framework](https://github.com/ocsf?utm_campaign=itb&utm_medium=newsletter&utm_source=morning_brew)
 


### PR DESCRIPTION
Jekyll renderował je jako tabelki. Dodatkowo link do twittera miał w nawiasie opis, nawias zamykający został przeniesiony