### PR TITLE
Add hidden training for JSON output only

### DIFF
--- a/data/trainings/09032026-testowy.yaml
+++ b/data/trainings/09032026-testowy.yaml
@@ -1,0 +1,16 @@
+id: "09032026-testowy"
+title: "Testowy"
+active: true
+
+# Prowadzący
+instructor: "Łukasz Kałużny"
+
+# Organizacja
+purchase_url: "https://cart.easy.tools/checkout/patoarchitekci/09032026-testowy"
+
+dates:
+  - "2026-03-09"
+time: "9:30 – 17:00"
+
+# To szkolenie jest ukryte - nie ma pliku markdown w /content/szkolenia/
+# więc Hugo nie wygeneruje dla niego strony, ale pojawi się w JSON


### PR DESCRIPTION
Add Testowy training (09.03.2026) conducted by Łukasz.
This training appears in the JSON API but has no corresponding
content page (no markdown file in /content/szkolenia/).