### PR TITLE
Hide test training from listing while keeping it in JSON

### DIFF
--- a/data/trainings/09032026-testowy.yaml
+++ b/data/trainings/09032026-testowy.yaml
@@ -1,6 +1,7 @@
 id: "09032026-testowy"
 title: "Testowy"
 active: true
+hidden: true
 
 # Prowadzący
 instructor: "Łukasz Kałużny"

--- a/layouts/partials/training-sorter.html
+++ b/layouts/partials/training-sorter.html
@@ -10,7 +10,9 @@
 {{- $pastTrainings := slice -}}
 
 {{- /* Separate trainings into future and past, adding firstDate field for sorting */ -}}
+{{- /* Skip hidden trainings (used for test/JSON-only trainings) */ -}}
 {{- range . -}}
+  {{- if not .hidden -}}
   {{- if .dates -}}
     {{- $firstDate := index .dates 0 -}}
     {{- /* Add firstDate field to training object for proper sorting */ -}}
@@ -25,6 +27,7 @@
     {{- /* Trainings without dates go to the end */ -}}
     {{- $training := merge . (dict "firstDate" "") -}}
     {{- $pastTrainings = $pastTrainings | append $training -}}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Add hidden flag to test training to prevent it from appearing on
/szkolenia/ page while still including it in trainings JSON output.