### PR TITLE
Fix HTML-encoded quotes in episode 177 title

### DIFF
--- a/content/episodes/177.md
+++ b/content/episodes/177.md
@@ -1,5 +1,5 @@
 ---
-title: '#177 Intro &#34;Chmura at scale&#34; | #Discord '
+title: '#177 Intro "Chmura at scale" | #Discord'
 date: 2026-01-16T08:00:00+02:00
 episode: "177"
 tags: ["Cloud Native", "Governance", "Security", "Azure", "Enterprise Architecture"]

--- a/scripts/podcast_post_hugo.md.j2
+++ b/scripts/podcast_post_hugo.md.j2
@@ -1,5 +1,5 @@
 ---
-title: '#{{ episode.episode_number }} {{ episode.title | replace("\n", " ") | replace("\r", " ") | escape }}'
+title: '#{{ episode.episode_number }} {{ episode.title | replace("\n", " ") | replace("\r", " ") }}'
 date: {{ episode.date }}T08:00:00+02:00
 episode: "{{ episode.episode_number }}"
 tags: [{{ tags | map('tojson') | join(', ') }}]


### PR DESCRIPTION
Replace &#34; HTML entities with actual quote characters
to fix title display on external services.