### PR TITLE
Architektura 101: zmiana na listę rezerwową

### DIFF
--- a/data/trainings/architektura-101.yaml
+++ b/data/trainings/architektura-101.yaml
@@ -2,7 +2,7 @@ id: "architektura-101"
 title: "Architektura 101"
 active: true
 featured: true
-waitlist_only: false
+waitlist_only: true
 
 # Prowadzący i meta
 instructor: "Łukasz Kałużny"


### PR DESCRIPTION
Szkolenie zapełnione - zapisy tylko na listę rezerwową.