### PR TITLE
Update Grafana observability training: enable waitlist, adjust pricing and dates

### DIFF
--- a/data/trainings/observability-stos-grafana.yaml
+++ b/data/trainings/observability-stos-grafana.yaml
@@ -2,7 +2,7 @@ id: "observability-stos-grafana"
 title: "Observability ze stosem Grafana"
 active: true
 featured: true
-waitlist_only: false
+waitlist_only: true
 
 # Prowadzący i meta
 instructor: "Szymon Warda"
@@ -92,17 +92,15 @@ benefits:
     description: "90% czasu to konkretne ćwiczenia - nie dla mięczaków"
 
 # Organizacja
-# price_net: 2031.71
-# price_gross: 2499.00
-price_net: 1625.20
-price_gross: 1999.00
+price_net: 2031.71
+price_gross: 2499.00
 currency: "PLN"
 purchase_url: "https://cart.easy.tools/checkout/patoarchitekci/observability-ze-stosem-grafana"
 
 dates:
-  - "2026-02-16"
-  - "2026-02-17"
-  - "2026-02-18"
+  - "2026-03-02"
+  - "2026-03-03"
+  - "2026-03-04"
 time: "9:00 – 13:00"
 
 location:

--- a/data/trainings/observability-stos-grafana.yaml
+++ b/data/trainings/observability-stos-grafana.yaml
@@ -92,8 +92,8 @@ benefits:
     description: "90% czasu to konkretne ćwiczenia - nie dla mięczaków"
 
 # Organizacja
-price_net: 2031.71
-price_gross: 2499.00
+price_net: 2357.72
+price_gross: 2899.00
 currency: "PLN"
 purchase_url: "https://cart.easy.tools/checkout/patoarchitekci/observability-ze-stosem-grafana"
 


### PR DESCRIPTION
## Summary
Updated the Grafana observability training configuration to enable waitlist mode, adjust pricing, and reschedule the training dates.

## Key Changes
- **Waitlist Mode**: Enabled waitlist-only registration (`waitlist_only: true`) for this training
- **Pricing Update**: 
  - Net price increased from 1,625.20 PLN to 2,357.72 PLN
  - Gross price increased from 1,999.00 PLN to 2,899.00 PLN
- **Training Dates**: Rescheduled from February 16-18, 2026 to March 2-4, 2026
  - Previous: 2026-02-16, 2026-02-17, 2026-02-18
  - New: 2026-03-02, 2026-03-03, 2026-03-04

## Notes
The pricing adjustment appears to reflect the original intended pricing (previously commented out), suggesting this may be a correction to the training cost structure.

https://claude.ai/code/session_01GrrjX94kY1wogeSNS2rgPj