### PR TITLE
Mark MCP Masterclass and eBPF trainings as waitlist only

### DIFF
--- a/data/trainings/model-context-protocol-mcp-masterclass.yaml
+++ b/data/trainings/model-context-protocol-mcp-masterclass.yaml
@@ -2,6 +2,7 @@ id: "model-context-protocol-mcp-masterclass"
 title: "Model Context Protocol (MCP) Masterclass"
 active: true
 featured: true
+waitlist_only: true
 
 # Prowadzący i meta
 instructor: "Łukasz Kałużny"

--- a/data/trainings/profilowanie-aplikacji-ebpf.yaml
+++ b/data/trainings/profilowanie-aplikacji-ebpf.yaml
@@ -2,6 +2,7 @@ id: "profilowanie-aplikacji-ebpf"
 title: "Profilowanie aplikacji z użyciem eBPF"
 active: true
 featured: true
+waitlist_only: true
 
 # Prowadzący i meta
 instructor: "Szymon Warda"


### PR DESCRIPTION
## Summary
Updated two training courses to be available only through waitlist registration by adding the `waitlist_only: true` flag to their configuration files.

## Changes
- Added `waitlist_only: true` to Model Context Protocol (MCP) Masterclass training
- Added `waitlist_only: true` to Profilowanie aplikacji z użyciem eBPF (Application Profiling with eBPF) training

## Details
Both trainings were already marked as active and featured. This change restricts their availability to waitlist-based registration only, likely due to capacity constraints or high demand.

https://claude.ai/code/session_01GMMkNk2fT5BAG6Y8AjHJQy