### PR TITLE
Enable public registration for Grafana observability training

### DIFF
--- a/data/trainings/observability-stos-grafana.yaml
+++ b/data/trainings/observability-stos-grafana.yaml
@@ -2,7 +2,7 @@ id: "observability-stos-grafana"
 title: "Observability ze stosem Grafana"
 active: true
 featured: true
-waitlist_only: true
+waitlist_only: false
 
 # Prowadzący i meta
 instructor: "Szymon Warda"


### PR DESCRIPTION
## Summary
This change opens up the "Observability ze stosem Grafana" training course to public registration by disabling the waitlist-only restriction.

## Key Changes
- Changed `waitlist_only` from `true` to `false` for the observability-stos-grafana training course

## Details
The training course is now publicly available for registration instead of being restricted to waitlist-only access. This allows interested participants to directly enroll in the course without needing prior approval or waitlist acceptance.

https://claude.ai/code/session_01QCSpHYDrpwmeKv9DWwNNin