### PR TITLE
fix: auto-update footer year using Hugo's now.Year

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -62,7 +62,7 @@ disableKinds = ["taxonomy", "term"]
 
   # Footer
   [params.footer]
-    copyright = "© Protopia 2025"
+    copyright = "Protopia"
 
   # Szkolenia - globalne dane
   [params.trainings]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -100,7 +100,7 @@
             {{ end }}
           </ul>
           <p class="text-white text-[10px] leading-120 sm:text-base">
-            {{ .Site.Params.footer.copyright }} <br />
+            &copy; {{ .Site.Params.footer.copyright }} {{ now.Year }} <br />
             <a href="{{ .Site.Params.legal.privacyPolicy }}" class="hover:text-orange">Polityka prywatności</a><br />
             <a href="{{ .Site.Params.legal.terms }}" class="hover:text-orange">Regulamin</a>
           </p>


### PR DESCRIPTION
Replace hardcoded "© Protopia 2025" with dynamic year generation
using Hugo's {{ now.Year }} template function so the copyright
year updates automatically on each build.

https://claude.ai/code/session_01NEbBPfQ8Stz8YqL4AkAVXE