### PR TITLE
Update Agentic AI training: add waitlist flag and reschedule date

### DIFF
--- a/data/trainings/agentic-ai-the-hard-way.yaml
+++ b/data/trainings/agentic-ai-the-hard-way.yaml
@@ -2,6 +2,7 @@ id: "agentic-ai-the-hard-way"
 title: "Agentic AI the Hard Way"
 active: true
 featured: true
+waitlist_only: false
 
 # Prowadzący i meta
 instructor: "Łukasz Kałużny"
@@ -110,7 +111,7 @@ currency: "PLN"
 purchase_url: "https://cart.easy.tools/checkout/patoarchitekci/agentic-ai-the-hard-way"
 
 dates:
-  - "2026-02-24"
+  - "2026-05-26"
 time: "9:30 – 17:00"
 
 location:


### PR DESCRIPTION
## Summary
Updated the "Agentic AI the Hard Way" training configuration with administrative changes to the waitlist status and training date.

## Key Changes
- Added `waitlist_only: false` flag to explicitly mark the training as open for direct registration (not waitlist-only)
- Rescheduled training date from February 24, 2026 to May 26, 2026

## Details
These changes reflect updates to the training's availability and scheduling. The addition of the `waitlist_only` field provides explicit configuration for the training's registration status, while the date change accommodates the new training schedule.

https://claude.ai/code/session_019cPvtWJJybZBct5YG6NrX6