### PR TITLE
Wyłącz szkolenia Grafana Masterclass i Grafana Alerting

### DIFF
--- a/data/trainings/grafana-alerting.yaml
+++ b/data/trainings/grafana-alerting.yaml
@@ -1,7 +1,7 @@
 id: "grafana-alerting"
 title: "Alerting w Grafanie - Sztuka Powiadamiania i Reagowania na Incydenty"
-active: true
-featured: true
+active: false
+featured: false
 
 # Prowadzący i meta
 instructor: "Szymon Warda"

--- a/data/trainings/grafana-masterclass.yaml
+++ b/data/trainings/grafana-masterclass.yaml
@@ -1,7 +1,7 @@
 id: "grafana-masterclass"
 title: "Grafana Masterclass – pełny przegląd i praktyka"
-active: true
-featured: true
+active: false
+featured: false
 
 # Prowadzący i meta
 instructor: "Szymon Warda"


### PR DESCRIPTION
Ustawiono active: false i featured: false dla obu szkoleń,
które nie będą się odbywać.

https://claude.ai/code/session_01QWmt1P2M6oFG2x1CVAtEPg