### PR TITLE
Enable waitlist for featured training courses

### DIFF
--- a/data/trainings/github-actions-w-praktyce.yaml
+++ b/data/trainings/github-actions-w-praktyce.yaml
@@ -2,6 +2,7 @@ id: "github-actions-w-praktyce"
 title: "GitHub Actions w Praktyce"
 active: true
 featured: true
+waitlist_only: true
 
 # Prowadzący i meta
 instructor: "Szymon Warda"

--- a/data/trainings/modelowanie-danych.yaml
+++ b/data/trainings/modelowanie-danych.yaml
@@ -2,6 +2,7 @@ id: "modelowanie-danych"
 title: "Modelowanie Danych"
 active: true
 featured: true
+waitlist_only: true
 
 # Prowadzący i meta
 instructor: "Szymon Warda"

--- a/data/trainings/observability-stos-grafana.yaml
+++ b/data/trainings/observability-stos-grafana.yaml
@@ -2,7 +2,7 @@ id: "observability-stos-grafana"
 title: "Observability ze stosem Grafana"
 active: true
 featured: true
-waitlist_only: false
+waitlist_only: true
 
 # Prowadzący i meta
 instructor: "Szymon Warda"
@@ -75,10 +75,6 @@ modules:
   - number: 8
     title: "Cost optimization"
     description: "Jak monitorować efektywnie bez rujnowania budżetu IT"
-  - number: 9
-    title: "Praktyczne warsztaty"
-    description: "Budowa kompletnego systemu observability od podstaw"
-
 benefits:
   - title: "Open Source bez kompromisów"
     description: "Potężny system monitorowania bez kosztów licencyjnych wielkich graczy"

--- a/data/trainings/wykrywanie-anomalii-prometheus-grafana.yaml
+++ b/data/trainings/wykrywanie-anomalii-prometheus-grafana.yaml
@@ -2,6 +2,7 @@ id: "wykrywanie-anomalii-prometheus-grafana"
 title: "Wykrywanie Anomalii jak Prawdziwy Architekt! - Warsztaty z Prometheus i Grafana"
 active: true
 featured: true
+waitlist_only: true
 
 # Prowadzący i meta
 instructor: "Szymon Warda"


### PR DESCRIPTION
## Summary
This PR enables waitlist-only mode for multiple featured training courses and removes a module from the Grafana observability training.

## Key Changes
- **Observability ze stosem Grafana**: Changed `waitlist_only` from `false` to `true` and removed module 9 ("Praktyczne warsztaty")
- **GitHub Actions w Praktyce**: Added `waitlist_only: true`
- **Modelowanie Danych**: Added `waitlist_only: true`
- **Wykrywanie Anomalii - Prometheus i Grafana**: Added `waitlist_only: true`

## Details
All four featured training courses are now restricted to waitlist-only enrollment. This likely indicates capacity constraints or a shift in the registration strategy for these popular courses. The removal of the practical workshop module from the Grafana training may reflect curriculum restructuring or scheduling adjustments.

https://claude.ai/code/session_011hsaUvGje9uRUi27jgnTZk