### PR TITLE
Add featured Pato Conference #200 event block to links page

### DIFF
--- a/layouts/links/single.html
+++ b/layouts/links/single.html
@@ -19,6 +19,43 @@
       </p>
     </div>
 
+    <!-- ===== KONFERENCJA PATO #200 (WYRÓŻNIONY BLOK) ===== -->
+    <a href="https://patoarchitekci.io/konferencja/" target="_blank" rel="noopener noreferrer"
+      class="w-full relative overflow-hidden rounded-2xl group block">
+      <div class="absolute inset-0 bg-gradient-to-br from-orange via-orange to-[#ff8a3d]"></div>
+      <div class="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-1000 ease-out"></div>
+      <div class="relative px-5 py-5 sm:py-6 flex flex-col items-center text-center gap-2">
+        <div class="flex items-center gap-2 text-dark-black">
+          <span class="inline-block px-2 py-0.5 bg-dark-black text-orange text-[10px] sm:text-xs font-bold uppercase font-tomorrow rounded-full tracking-wider">Nowość</span>
+          <span class="text-dark-black text-xs sm:text-sm font-bold uppercase font-tomorrow tracking-wider">Konferencja Pato</span>
+        </div>
+        <div class="font-tomorrow font-black text-dark-black text-2xl sm:text-3xl uppercase leading-none">
+          #200 na żywo
+        </div>
+        <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-dark-black font-semibold text-xs sm:text-sm">
+          <span class="flex items-center gap-1.5">
+            <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
+            </svg>
+            16 czerwca 2026
+          </span>
+          <span class="hidden sm:inline">&middot;</span>
+          <span class="flex items-center gap-1.5">
+            <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/>
+            </svg>
+            Warszawa
+          </span>
+        </div>
+        <div class="mt-2 inline-flex items-center gap-2 bg-dark-black text-white font-bold text-sm sm:text-base uppercase font-tomorrow rounded-full py-2 px-5 group-hover:bg-white group-hover:text-dark-black transition-colors duration-300">
+          Weź udział
+          <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/>
+          </svg>
+        </div>
+      </div>
+    </a>
+
     <!-- ===== DOŁĄCZ DO DISCORD ===== -->
     {{ with .Site.Params.social.discord }}
     <a href="{{ . }}" target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
Added a prominent featured event block for the Pato Conference #200 live event to the links page layout.

## Key Changes
- Added a new featured conference announcement block with an eye-catching orange gradient background
- Included event details: date (June 16, 2026) and location (Warsaw)
- Implemented interactive hover effects with a shimmer animation and button color transition
- Positioned the block between the intro section and Discord link for maximum visibility
- Used responsive design with Tailwind CSS to ensure proper display across mobile and desktop viewports

## Implementation Details
- The block features a gradient background (`from-orange via-orange to-[#ff8a3d]`) with a hover shimmer effect
- Event information is displayed with icons (calendar and location) for better visual hierarchy
- "Nowość" (New) badge highlights the event as a recent addition
- Call-to-action button ("Weź udział" - Take part) with hover state that inverts colors
- Fully responsive typography and spacing using Tailwind's `sm:` breakpoints
- External link opens in a new tab with proper security attributes (`target="_blank" rel="noopener noreferrer"`)

https://claude.ai/code/session_0131STQNjYKPEb6KSzEJQEQk