### PR TITLE
Add performer field to Konferencja Pato #200 Event schema

### DIFF
--- a/static/konferencja/index.html
+++ b/static/konferencja/index.html
@@ -56,6 +56,13 @@
       "name": "Patoarchitekci",
       "url": "https://patoarchitekci.io"
     },
+    "performer": [
+      { "@type": "Person", "name": "Łukasz Kałużny", "sameAs": "https://www.linkedin.com/in/lukaszkaluzny/" },
+      { "@type": "Person", "name": "Szymon Warda", "sameAs": "https://www.linkedin.com/in/szymonwarda/" },
+      { "@type": "Person", "name": "Oskar Dudycz", "sameAs": "https://www.linkedin.com/in/oskardudycz/" },
+      { "@type": "Person", "name": "Mariusz Gil", "sameAs": "https://www.linkedin.com/in/mariuszgil/" },
+      { "@type": "Person", "name": "Mariusz Dalewski", "sameAs": "https://www.linkedin.com/in/mariuszdalewski/" }
+    ],
     "offers": {
       "@type": "Offer",
       "url": "https://cart.easy.tools/checkout/patoarchitekci/konferencja-pato-200",


### PR DESCRIPTION
Fixes Google Search Console non-critical warning about missing "performer". Adds all 5 speakers as Person entries with LinkedIn sameAs.